### PR TITLE
feat: Add automated seeding script for default admin and teacher users on fresh setup

### DIFF
--- a/backend/setupAdmin.js
+++ b/backend/setupAdmin.js
@@ -1,0 +1,114 @@
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+const User = require('./src/models/User');
+const School = require('./src/models/School');
+
+async function setupAdmin() {
+  try {
+    console.log('Starting admin setup...');
+    
+    if (!process.env.MONGODB_URI) {
+      console.error('MONGODB_URI not found in .env file');
+      console.log('Please add MONGODB_URI to your .env file');
+      console.log('Example: MONGODB_URI=mongodb://localhost:27017/classsync');
+      process.exit(1);
+    }
+
+    await mongoose.connect(process.env.MONGODB_URI);
+    console.log('Connected to MongoDB');
+
+    let school = await School.findOne({ name: 'Demo School' });
+    if (!school) {
+      school = new School({
+        name: 'Demo School',
+        timetableConfig: {
+          periodCount: 8,
+          periodDurationMinutes: 45,
+          startHour: 8,
+          startMinute: 0
+        }
+      });
+      await school.save();
+      console.log('Created Demo School');
+    } else {
+      console.log('Demo School already exists');
+    }
+
+    // Check if admin already exists
+    const existingAdmin = await User.findOne({ email: 'admin@demo.com' });
+    if (existingAdmin) {
+      console.log('Admin user already exists');
+      console.log('Removing existing admin to create fresh one...');
+      await User.deleteOne({ email: 'admin@demo.com' });
+    }
+
+    // Create admin user with proper password hashing
+    const adminPassword = 'Admin@123';
+    const saltRounds = 10;
+    const hashedPassword = await bcrypt.hash(adminPassword, saltRounds);
+
+    const adminUser = new User({
+      name: 'Admin',
+      email: 'admin@demo.com',
+      password: hashedPassword,
+      role: 'admin',
+      schoolId: school._id,
+      isActive: true
+    });
+
+    await adminUser.save();
+    console.log('Created admin user');
+
+    //Verify the setup
+    console.log('\nSetup Summary:');
+    console.log(`   School: ${school.name} (ID: ${school._id})`);
+    console.log(`   Admin Email: ${adminUser.email}`);
+    console.log(`   Admin Role: ${adminUser.role}`);
+    console.log(`   Password: ${adminPassword}`);
+
+    const isPasswordValid = await bcrypt.compare(adminPassword, hashedPassword);
+    if (isPasswordValid) {
+      console.log('Password verification test passed');
+    } else {
+      console.log('Password verification test failed');
+    }
+
+    //Create demo teacher
+    const existingTeacher = await User.findOne({ email: 'teacher@demo.com' });
+    if (existingTeacher) {
+      console.log('Removing existing teacher to create fresh one...');
+      await User.deleteOne({ email: 'teacher@demo.com' });
+    }
+
+    const teacherPassword = 'piyush@123';
+    const hashedTeacherPassword = await bcrypt.hash(teacherPassword, saltRounds);
+
+    const teacherUser = new User({
+      name: 'Demo Teacher',
+      email: 'teacher@demo.com',
+      password: hashedTeacherPassword,
+      role: 'teacher',
+      schoolId: school._id,
+      isActive: true
+    });
+
+    await teacherUser.save();
+    console.log('Created demo teacher user');
+
+    console.log('\nSetup completed successfully!');
+    console.log('\nLogin Credentials:');
+    console.log('   Admin: admin@demo.com / Admin@123');
+    console.log('   Teacher: teacher@demo.com / piyush@123');
+    
+    process.exit(0);
+
+  } catch (error) {
+    console.error('Setup failed:', error.message);
+    console.error('Full error:', error);
+    process.exit(1);
+  }
+}
+
+setupAdmin();


### PR DESCRIPTION
Fixes #21

## Type of Change
Please delete options that are not relevant 
- [ ] Bug fix 
- [x] New feature 
- [ ] Documentation update
- [ ] Code Refactoring
- [ ] UI/UX enhancement


## Checklist
- [x] My code follows the contribution guidelines.
- [x] I have tested my changes on **local dev** environment.
- [ ] I have added necessary documentation/comments.
- [x] I have linked the related Issue in this PR.
- [ ] I have mentioned relevant reviewers (if applicable).


This PR introduces an automated seeding script (`setupAdmin.js`) that:
- Connects to the MongoDB database using the credentials from `.env`.
- Creates a default school if it does not exist.
- Properly hashes passwords using bcrypt.
- Inserts a default admin user (`admin@demo.com` / `Admin@123`) and a demo teacher (`teacher@demo.com` / `piyush@123`) with all required fields and correct references.
- Cleans up any existing users with those emails to avoid duplicates.
- Can be safely run multiple times.


start the script by
 ```
node setupAdmin.js
```
<img width="955" height="525" alt="image" src="https://github.com/user-attachments/assets/bb119fba-5b68-44e8-9f99-fb77f5460ef7" />

