### PR TITLE
fix: close chatbot popup on outside click

### DIFF
--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -14,10 +14,31 @@ const Chatbot = () => {
   const [isTyping, setIsTyping] = useState(false);
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
+    const chatRef = useRef(null);
+
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
+
+
+useEffect(() => {
+  const handleClickOutside = (event) => {
+    if (chatRef.current && !chatRef.current.contains(event.target)) {
+      setOpen(false);
+    }
+  };
+
+  if (open) {
+    document.addEventListener('mousedown', handleClickOutside);
+  }
+
+  return () => {
+    document.removeEventListener('mousedown', handleClickOutside);
+  };
+}, [open]);
+
+
 
   useEffect(() => {
     scrollToBottom();
@@ -107,7 +128,9 @@ const Chatbot = () => {
 
       {/* Chat Window */}
       {open && (
-        <div className="absolute bottom-16 right-0 w-[90vw] sm:w-96 h-[32rem] bg-white/95 backdrop-blur-md border border-indigo-100 rounded-2xl shadow-2xl overflow-hidden transform transition-all duration-300 animate-in slide-in-from-bottom-4 fade-in">
+        <div 
+         ref={chatRef}
+        className="absolute bottom-16 right-0 w-[90vw] sm:w-96 h-[32rem] bg-white/95 backdrop-blur-md border border-indigo-100 rounded-2xl shadow-2xl overflow-hidden transform transition-all duration-300 animate-in slide-in-from-bottom-4 fade-in">
           {/* Header */}
           <div className="bg-gradient-to-r from-indigo-500 to-indigo-600 px-6 py-4 text-white">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
✨ Description
I’ve implemented a feature where the popup now closes when a user clicks anywhere outside it. 

The logic uses a ref on the chat container and a useEffect hook to detect and handle outside clicks using mousedown events. The change is smooth, clean, and fully tested on the local development setup.

✅ Type of Change

 Bug fix

 New feature


### **Before**: 


https://github.com/user-attachments/assets/451fe16f-5b6c-4c06-a268-b735ec63b0cf



### **After**: 



https://github.com/user-attachments/assets/0709162e-04af-42e4-a426-dcdc27444417






📝 Checklist

 My code follows the contribution guidelines.

 I have tested my changes on local dev environment.

 I have added necessary documentation/comments.

 I have linked the related Issue in this PR.

 I have mentioned relevant reviewers (if applicable).
