### PR TITLE
Bhavana/enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,16 @@ We welcome contributions from the community! To contribute:
 
 Thank you for helping improve ClassSync! 
 
-<p align="center">
-  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
-    ⬆️ Back to Top
-  </a>
-</p>
-
 ---
 
 ## 📄 License
 This project is licensed under the [MIT License](LICENSE).
 
+---
+
+
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ClassSync
+<!-- top -->
 
 > **A Modern School Management Platform for Effortless Scheduling, Leave, and Substitution Management**
 
@@ -109,3 +110,9 @@ We welcome contributions from the community! To contribute:
 - All contributions will be reviewed before merging.
 
 Thank you for helping improve ClassSync! 
+
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>


### PR DESCRIPTION
Hello @dhananjay6561 As per our discussion earlier, I have raised the PR again, kindly verify this one and let me know

The current README.md is too long and contains multiple sections. Scrolling through it can be cumbersome, especially for new users or contributors accessing it on smaller screens.

💡 Proposed Solution
Add [🔝 Back to Top] links at the end of major sections in the README

Optionally add a top anchor like (though GitHub supports #readme by default)

Maintain consistent formatting across all sections

Please check the most recent commit and assign this as level 1

Issue number #14 